### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "asn1.js": "1.0.3"
+    "asn1.js": "^5.0.1"
   },
   "devDependencies": {
     "tap": "0.7.1"


### PR DESCRIPTION
old version that lists bn.js as an optional dependency
https://github.com/indutny/asn1.js/blob/v1.0.3/package.json

In our production we use npm install --no-optional and
it doesnt end up picking it up