### PR TITLE
Use safe buffer so code works fine in browserify context

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var Buffer = require('safe-buffer').Buffer;
 var asn = require('asn1.js')
 var factor = require('./factor')
 var one = new asn.bignum(1)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "license": "MPL-2.0",
   "dependencies": {
-    "asn1.js": "^5.0.1"
+    "asn1.js": "^5.0.1",
+    "safe-buffer": "^5.1.2"
   },
   "devDependencies": {
     "tap": "^12.1.1"


### PR DESCRIPTION
When using code through browserify, it complains that base64 is not a function
This is due to differing Buffer.from being different in browserify. For some reason I couldn't figure out it was calling Function.from not Buffer.from

Anyways super module wrapper that makes browserify happy

In theory `var Buffer = require('buffer').Buffer;` should do the same thing but from my limited tests, browserify didn't replace the Buffer object